### PR TITLE
Various minute changes

### DIFF
--- a/makefile
+++ b/makefile
@@ -5,7 +5,7 @@
  #
    
 CC=gcc
-CFLAGS=-O2 -ansi
+CFLAGS=-O2 -ansi -Wall -Wextra -Wpedantic
 LDFLAGS=-lcurl
 SRCDIR=src
 INCLUDES=-Iinclude

--- a/makefile
+++ b/makefile
@@ -5,7 +5,7 @@
  #
    
 CC=gcc
-CFLAGS=-O2 -ansi -Wall -Wextra -Wpedantic
+CFLAGS=-O2 --std=c99 -Wall -Wextra -Wpedantic
 LDFLAGS=-lcurl
 SRCDIR=src
 INCLUDES=-Iinclude

--- a/src/utilities.c
+++ b/src/utilities.c
@@ -25,7 +25,11 @@ char *create_filebuffer(const char *filename)
 	long pos = ftell(fp);
 	char *buffer = (char *) malloc(sizeof(char) * pos + 1);
 	fseek(fp, 0, SEEK_SET);
-	fread(buffer, pos, 1, fp);
+	if(fread(buffer, pos, 1, fp) != 1) 
+	{
+		perror("[!] Failed to read file.\n");
+		abort();
+	}
 	fclose(fp);
 	buffer[pos] = '\0'; /* null terminate */
 	return buffer;

--- a/src/utilities.c
+++ b/src/utilities.c
@@ -18,7 +18,7 @@ char *create_filebuffer(const char *filename)
 	FILE *fp = fopen(filename, "r");
 	if (!fp)
 	{
-		perror("[!] Could not open file.\n");
+		perror("[!] Could not open file");
 		abort();
 	}
 	fseek(fp, 0, SEEK_END);
@@ -27,7 +27,7 @@ char *create_filebuffer(const char *filename)
 	fseek(fp, 0, SEEK_SET);
 	if(fread(buffer, pos, 1, fp) != 1) 
 	{
-		perror("[!] Failed to read file.\n");
+		perror("[!] Failed to read file");
 		abort();
 	}
 	fclose(fp);


### PR DESCRIPTION
Enabled -Wall -Wextra and -Wpedantic in makefile.
Using c99 instead of c89 or c90 eradicates 81 warnings.
fread() is declared with attribute warn_unused_result and its return value should be checked.
perror() formats the error message adds info and a new line at the end, therefore this need not be done by the user.
